### PR TITLE
Updated logging to append to the same file instead

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
     if err != nil {
         fmt.Println(err)
     }
+    fmt.Fprintln(logHandle, "FORWARDING REQUEST TO BACKEND")
     fmt.Fprintln(logHandle, string(dump))
 
     resignHeader(r)
@@ -55,6 +56,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
     if err != nil {
         fmt.Println(err)
     }
+    fmt.Fprintln(logHandle, "FORWARDING RESPONSE TO CLIENT")
     fmt.Fprintln(logHandle, string(responseDump))
 
     for header, values := range response.Header {


### PR DESCRIPTION
Since one s3cmd can generate multiple requests the request and response
is now dumped to the same file in which everything is appended instead,
so it's possible to trace the entire run.