### PR TITLE
Read files, not symlinks or folders

### DIFF
--- a/userauth.go
+++ b/userauth.go
@@ -200,7 +200,7 @@ func (u *ValidateFromToken) getjwtkey(jwtpubkeypath string) error {
 			if err != nil {
 				return err
 			}
-			if string(info.Mode().String()[0]) == "-" {
+			if info.Mode().IsRegular() {
 				log.Debug("reading file: ", filepath.Join(filepath.Clean(jwtpubkeypath), info.Name()))
 				keyData, err := ioutil.ReadFile(filepath.Join(filepath.Clean(jwtpubkeypath), info.Name()))
 				if err != nil {


### PR DESCRIPTION
Due to the way k8s injects files into a container we need to make sure we read the file and not try to read symlinks or folders.