### PR TITLE
Fixed username extraction and testing

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -244,7 +244,7 @@ func (p *Proxy) detectRequestType(r *http.Request) S3RequestType {
 // figure out the correct message to send from it.
 func (p *Proxy) CreateMessageFromRequest(r *http.Request) (Event, error) {
 	// Extract username for request's url path
-	re := regexp.MustCompile("/([^/]+)/")
+	re := regexp.MustCompile("/[^/]+/([^/]+)/")
 	username := re.FindStringSubmatch(r.URL.Path)[1]
 
 	event := Event{}
@@ -269,7 +269,6 @@ func (p *Proxy) CreateMessageFromRequest(r *http.Request) (Event, error) {
 	event.Username = username
 	checksum.Type = "etag"
 	event.Checksum = checksum
-
 	return event, nil
 }
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -287,7 +287,7 @@ func TestServeHTTP_allowed(t *testing.T) {
 func TestMessageFormatting(t *testing.T) {
 	f := startFakeServer("9023")
 	// Set up basic request for multipart upload
-	r, _ := http.NewRequest("POST", "/user/new_file.txt", nil)
+	r, _ := http.NewRequest("POST", "/buckbuck/user/new_file.txt", nil)
 	r.Host = "localhost"
 	r.Header.Set("content-length", "1234")
 	r.Header.Set("x-amz-content-sha256", "checksum")
@@ -309,7 +309,7 @@ func TestMessageFormatting(t *testing.T) {
 
 	assert.Equal(t, "multipart-upload", msg.Operation)
 	assert.Equal(t, int64(1234), msg.Filesize)
-	assert.Equal(t, "/user/new_file.txt", msg.Filepath)
+	assert.Equal(t, "/buckbuck/user/new_file.txt", msg.Filepath)
 	assert.Equal(t, "user", msg.Username)
 	assert.Equal(t, "etag", msg.Checksum.Type)
 	assert.Equal(t, "0a44282bd39178db9680f24813c41aec-1", msg.Checksum.Value)


### PR DESCRIPTION
The username was not extracted properly in the CreateMessageFromRequest. Fixed this and the related testing