### PR TITLE
Bugfix

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/minio/minio-go/v6/pkg/s3signer"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Proxy represents the toplevel object in this application
@@ -285,7 +284,7 @@ func (p *Proxy) CreateMessageFromRequest(r *http.Request) (Event, error) {
 // RequestInfo is a function that makes a request to the S3 and collects
 // the etag and size information for the uploaded document
 func (p *Proxy) requestInfo(fullPath string) (string, int64, error) {
-	filePath := strings.Replace(fullPath, "/"+viper.GetString("aws.bucket")+"/", "", 1)
+	filePath := strings.Replace(fullPath, "/"+p.s3.bucket+"/", "", 1)
 	s, err := p.newSession()
 	if err != nil {
 		return "", 0, err


### PR DESCRIPTION
Bugfixes for some issues that showed up when running the tests in our production environment.

The extra headers comes from the nginx ingress controller.
Why the file path can't start with a slash might need some more debugging to figure out, at least now the end result is what we expect.