### PR TITLE
bump version & publish dockerhub & github registry #none

### DIFF
--- a/.github/workflows/tag_and_build.yaml
+++ b/.github/workflows/tag_and_build.yaml
@@ -1,0 +1,71 @@
+name: Bump version
+on:
+  push:
+    branches:
+    - master
+jobs:
+  tag:
+    name: bump tags
+    outputs:
+      part: ${{ steps.bump_tag.outputs.part }}
+      tag: ${{ steps.bump_tag.outputs.tag }}
+      new_tag: ${{ steps.bump_tag.outputs.new_tag }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '2'
+    - name: Bump version and push tag
+      id: bump_tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch
+
+  push_to_registry:
+    needs: tag
+    if: needs.tag.outputs.part != ''
+    name: Push Docker image to Github Container registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ needs.tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest
+            ${{ github.repository }}:${{ needs.tag.outputs.tag }}
+            ${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
This will bump the patch number on each PR merge unless the last commit message or the PR title contains **&#35;none**. 
In order to bump the major or minor version add **&#35;major** or **&#35;minor** to the last commit message or the PR title.

**&#35;major** -> v1.2.3 > 2.0.0
**&#35;minor** -> v1.2.3 > 1.3.0

If a new tag is created the second part of the action will build an docker image and publish it to the GithHub Container Registry.

### Changes made:
1. Action to automatically bump the tag on push to master or PR merge.
2. Builds new Docker image and published to GHCR when tag changes.
3. pushes to docker hub as well
