### PR TITLE
Added case to allow listing with AWS SDK

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -193,7 +193,7 @@ func (p *Proxy) prependBucketToHostPath(r *http.Request) {
 			r.URL.RawQuery = r.URL.RawQuery + "&prefix=" + username + "%2F"
 		}
 		log.Debug("new Raw Query: ", r.URL.RawQuery)
-	} else if r.Method == http.MethodGet && strings.Contains(r.URL.String(), "?location") {
+	} else if r.Method == http.MethodGet && (strings.Contains(r.URL.String(), "?location") || strings.Contains(r.URL.String(), "&prefix")) {
 		r.URL.Path = "/" + bucket + "/"
 		log.Debug("new Path: ", r.URL.Path)
 	} else if r.Method == http.MethodPost || r.Method == http.MethodPut {


### PR DESCRIPTION
The pull request enables listing files in the sda-s3Proxy when using the AWS go SDK.

Before the introduced change, the proxy did not add the `bucket` to the url when trying to list files with the AWS SDK. Specifically, when using the `ListObjectsV2`, the proxy was attempting to list files using the `username` as `bucket` and therefore failing.