### PR TITLE
Start https server with defined timeout values

### DIFF
--- a/healthchecks.go
+++ b/healthchecks.go
@@ -44,7 +44,15 @@ func (h *HealthCheck) RunHealthChecks() {
 	health.AddReadinessCheck("broker-tcp", healthcheck.TCPDialCheck(h.brokerURL, 50*time.Millisecond))
 
 	addr := ":" + strconv.Itoa(h.port)
-	if err := http.ListenAndServe(addr, health); err != nil {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           health,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
HTTP timeouts are necessary to expire inactive connections and failing to do so might make the application vulnerable to attacks like slowloris which work by sending data very slow, which in case of no timeout will keep the connection active eventually leading to a denial-of-service (DoS) attack. ([CWE-400](https://cwe.mitre.org/data/definitions/400.html))