### PR TITLE
log CorrelationId on message sent in debug mode

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -122,7 +122,7 @@ func (m *AMQPMessenger) SendMessage(message Event) error {
 	if !confirmed.Ack {
 		return fmt.Errorf("failed delivery of delivery tag: %d", confirmed.DeliveryTag)
 	}
-	log.Debugf("confirmed delivery with delivery tag: %d", confirmed.DeliveryTag)
+	log.Debugf("Delivered message: %v, with correlation-ID: %v", string(body), corrID.String())
 
 	return nil
 


### PR DESCRIPTION
This PR solves #304 
The correlation ID will be logged in the debug mode when a message is sent to RabbitMQ at the completion of file uploading.