### PR TITLE
Fix/disallow filename characters

### DIFF
--- a/dev_utils/README.md
+++ b/dev_utils/README.md
@@ -51,10 +51,9 @@ mc admin trace -v proxydev
 Run the go proxy from the root directory
 
 ```bash
-export GO111MODULE=on
 export SERVER_CONFFILE=dev_utils/config.yaml
-go build main.go
-./main
+go build .
+./S3-Upload-Proxy
 ```
 
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -372,13 +372,13 @@ func TLScertToFile(filename string, derBytes []byte) error {
 func FormatUploadFilePath(filePath string) (string, error) {
 
 	// Check for mixed "\" and "/" in filepath. Stop and throw an error if true so that
-	// we do not end up with unintended folder structure when applying ToSlash later on
+	// we do not end up with unintended folder structure when applying ReplaceAll below
 	if strings.Contains(filePath, "\\") && strings.Contains(filePath, "/") {
 		return filePath, fmt.Errorf("filepath contains mixed '\\' and '/' characters")
 	}
 
-	// make path separators os compatible
-	outPath := filepath.ToSlash(filePath)
+	// make any windows path separators linux compatible
+	outPath := strings.ReplaceAll(filePath, "\\", "/")
 
 	// [\x00-\x1F\x7F] is the control character set
 	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -8,11 +8,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"log"
 	"math/big"
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -362,4 +365,28 @@ func TLScertToFile(filename string, derBytes []byte) error {
 	err = pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 
 	return err
+}
+
+// FormatUploadFilePath ensures that path separators are "/", and returns error if the
+// filepath contains a disallowed character matched with regex
+func FormatUploadFilePath(filePath string) (string, error) {
+
+	// Check for mixed "\" and "/" in filepath. Stop and throw an error if true so that
+	// we do not end up with unintended folder structure when applying ToSlash later on
+	if strings.Contains(filePath, "\\") && strings.Contains(filePath, "/") {
+		return filePath, fmt.Errorf("filepath contains mixed '\\' and '/' characters")
+	}
+
+	// make path separators os compatible
+	outPath := filepath.ToSlash(filePath)
+
+	// [\x00-\x1F\x7F] is the control character set
+	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
+
+	dissallowedChars := re.FindAllString(outPath, -1)
+	if dissallowedChars != nil {
+		return outPath, fmt.Errorf("filepath contains disallowed characters: %+v", strings.Join(dissallowedChars, ", "))
+	}
+
+	return outPath, nil
 }

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -2,8 +2,6 @@ package helper
 
 import (
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,24 +73,11 @@ func TestCreateECToken(t *testing.T) {
 
 func TestFormatUploadFilePath(t *testing.T) {
 
-	// This is non-trivial only on windows
 	unixPath := "a/b/c.c4gh"
-	testPath := filepath.Join("a", "b", "c.c4gh")
+	testPath := "a\\b\\c.c4gh"
 	uploadPath, err := FormatUploadFilePath(testPath)
 	assert.NoError(t, err)
 	assert.Equal(t, unixPath, uploadPath)
-
-	testPath = "a\\b\\c.c4gh"
-	uploadPath, err = FormatUploadFilePath(testPath)
-	if runtime.GOOS == "windows" {
-		// this is expected to work on windows
-		assert.Equal(t, unixPath, uploadPath)
-		assert.NoError(t, err)
-	} else {
-		// this is expected to fail on linux/mac
-		assert.ErrorContains(t, err, "filepath contains disallowed characters: \\, \\")
-
-	}
 
 	// mixed "\" and "/"
 	weirdPath := `dq\sw:*?"<>|\t\s/df.c4gh`
@@ -102,9 +87,6 @@ func TestFormatUploadFilePath(t *testing.T) {
 	// no mixed "\" and "/" but not allowed
 	weirdPath = `dq\sw:*?"<>|\t\sdf.c4gh`
 	_, err = FormatUploadFilePath(weirdPath)
-	if runtime.GOOS == "windows" {
-		assert.EqualError(t, err, "filepath contains disallowed characters: :, *, ?, \", <, >, |")
-	} else {
-		assert.EqualError(t, err, "filepath contains disallowed characters: \\, :, *, ?, \", <, >, |, \\, \\")
-	}
+	assert.EqualError(t, err, "filepath contains disallowed characters: :, *, ?, \", <, >, |")
+
 }

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -2,6 +2,8 @@ package helper
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,4 +71,40 @@ func TestCreateECToken(t *testing.T) {
 	assert.Nil(t, err)
 
 	defer os.RemoveAll("dummy-folder")
+}
+
+func TestFormatUploadFilePath(t *testing.T) {
+
+	// This is non-trivial only on windows
+	unixPath := "a/b/c.c4gh"
+	testPath := filepath.Join("a", "b", "c.c4gh")
+	uploadPath, err := FormatUploadFilePath(testPath)
+	assert.NoError(t, err)
+	assert.Equal(t, unixPath, uploadPath)
+
+	testPath = "a\\b\\c.c4gh"
+	uploadPath, err = FormatUploadFilePath(testPath)
+	if runtime.GOOS == "windows" {
+		// this is expected to work on windows
+		assert.Equal(t, unixPath, uploadPath)
+		assert.NoError(t, err)
+	} else {
+		// this is expected to fail on linux/mac
+		assert.ErrorContains(t, err, "filepath contains disallowed characters: \\, \\")
+
+	}
+
+	// mixed "\" and "/"
+	weirdPath := `dq\sw:*?"<>|\t\s/df.c4gh`
+	_, err = FormatUploadFilePath(weirdPath)
+	assert.EqualError(t, err, "filepath contains mixed '\\' and '/' characters")
+
+	// no mixed "\" and "/" but not allowed
+	weirdPath = `dq\sw:*?"<>|\t\sdf.c4gh`
+	_, err = FormatUploadFilePath(weirdPath)
+	if runtime.GOOS == "windows" {
+		assert.EqualError(t, err, "filepath contains disallowed characters: :, *, ?, \", <, >, |")
+	} else {
+		assert.EqualError(t, err, "filepath contains disallowed characters: \\, :, *, ?, \", <, >, |, \\, \\")
+	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -409,7 +409,6 @@ func (p *Proxy) requestInfo(fullPath string) (string, int64, error) {
 
 		return "", 0, err
 	}
-	fmt.Println(strings.ReplaceAll(*result.Contents[0].ETag, "\"", ""))
 
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.ReplaceAll(*result.Contents[0].ETag, "\"", "")))), *result.Contents[0].Size, nil
 

--- a/proxy.go
+++ b/proxy.go
@@ -90,7 +90,6 @@ func (p *Proxy) notAllowedResponse(w http.ResponseWriter, _ *http.Request) {
 
 func (p *Proxy) notAcceptableResponse(w http.ResponseWriter, _ *http.Request) {
 	log.Debug("not acceptable response")
-	// http.Error(w, "request not acceptable", 406)
 	w.WriteHeader(406)
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -78,24 +78,23 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) internalServerError(w http.ResponseWriter, r *http.Request) {
-	log.Debug("internal server error")
 	log.Debugf("Internal server error for request (%v)", r)
-	w.WriteHeader(500)
+	w.WriteHeader(http.StatusInternalServerError)
 }
 
 func (p *Proxy) notAllowedResponse(w http.ResponseWriter, _ *http.Request) {
 	log.Debug("not allowed response")
-	w.WriteHeader(403)
+	w.WriteHeader(http.StatusForbidden)
 }
 
 func (p *Proxy) notAcceptableResponse(w http.ResponseWriter, _ *http.Request) {
 	log.Debug("not acceptable response")
-	w.WriteHeader(406)
+	w.WriteHeader(http.StatusNotAcceptable)
 }
 
 func (p *Proxy) notAuthorized(w http.ResponseWriter, _ *http.Request) {
 	log.Debug("not authorized")
-	w.WriteHeader(401) // Actually correct!
+	w.WriteHeader(http.StatusUnauthorized)
 }
 
 func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {

--- a/proxy.go
+++ b/proxy.go
@@ -87,11 +87,6 @@ func (p *Proxy) notAllowedResponse(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusForbidden)
 }
 
-func (p *Proxy) notAcceptableResponse(w http.ResponseWriter, _ *http.Request) {
-	log.Debug("not acceptable response")
-	w.WriteHeader(http.StatusNotAcceptable)
-}
-
 func (p *Proxy) notAuthorized(w http.ResponseWriter, _ *http.Request) {
 	log.Debug("not authorized")
 	w.WriteHeader(http.StatusUnauthorized)
@@ -115,7 +110,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 	filepath, err := helper.FormatUploadFilePath(rawFilepath)
 	if err != nil {
 		log.Debugf(err.Error())
-		p.notAcceptableResponse(w, r)
+		w.WriteHeader(http.StatusNotAcceptable)
 
 		return
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -310,6 +310,16 @@ func (suite *ProxyTests) TestServeHTTP_allowed() {
 	proxy.ServeHTTP(w, r)
 	assert.Equal(suite.T(), 200, w.Result().StatusCode)
 	assert.Equal(suite.T(), true, suite.fakeServer.PingedAndRestore())
+
+	// Filenames with platform incompatible characters are disallowed
+	// not checked in TestServeHTTP_allowed() because we look for a non 403 response
+	r.Method = "PUT"
+	r.URL, _ = url.Parse("/username/fi|le")
+	w = httptest.NewRecorder()
+	proxy.ServeHTTP(w, r)
+	assert.Equal(suite.T(), 406, w.Result().StatusCode)
+	assert.Equal(suite.T(), false, suite.fakeServer.PingedAndRestore())
+
 }
 
 func (suite *ProxyTests) TestMessageFormatting() {


### PR DESCRIPTION

This PR prevents potential filepath naming problems that may arise due to cross-platform incompatibilities.

The procedure implemented is as follows:
- a filepath is first checked whether it contains both "/" and "\\". If yes, the request is rejected. This prevents generating erroneous folder structure in the next step.
- all file separators in the filepath are changed to the host's OS convention
- the resulting filepath is checked against a regex set of characters that we wish to disallow and if a hit is found the request is rejected.
In case of a rejection, `proxy` returns a 406 error response to the client and prints debug logs with details on the disallowed characters found in the filepath. Testsuite is updated, too.

The fix was tested for the case when `proxy` runs in linux and an s3 client (s3cmd, sda-cli) runs in either linux or windows. Not tested for mac but hopefully it behaves like linux ;-).

P.S. following standup discussion, spaces in filenames are allowed (along with the majority of unicode).

Closes #370